### PR TITLE
[ATSCALE-44228] row security property to UDA

### DIFF
--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -656,7 +656,7 @@ Supported properties:
 - `dimension`: String, required if `row_security` is undefined. The dimension to which the attribute
   defined by `name` belongs.
 
-  - `row_security`: String, required if `dimension` and `name` are
+- `row_security`: String, required if `dimension` and `name` are
   undefined. Allows to include row security in the user defined aggregate.
 
 - `partition`: String, optional. Adds a partition to the aggregate, and

--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -657,7 +657,7 @@ Supported properties:
   defined by `name` belongs.
 
 - `row_security`: String, required if `dimension` and `name` are
-  undefined. Allows to include row security in the user defined aggregate.
+  undefined. Allows row security to be included in a user defined aggregate.
 
 - `partition`: String, optional. Adds a partition to the aggregate, and
   determines whether it should be defined on the key column, name

--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -248,6 +248,7 @@ namespace Models{
     class AttributeReference{
       String name
       String dimension
+      String row_security
       String partition
       String distribution
       Array~String~ relationships_path
@@ -646,14 +647,17 @@ definition.
 
 Supported properties:
 
-- `name`: String, required. The name of the dimension attribute to
+- `name`: String, required if `row_security` is undefined. The name of the dimension attribute to
   include. These values are used to group the summarized metric data in
   the resulting aggregate table. Note that user-defined aggregate
   definitions are fixed: they do not include every level of a hierarchy
   unless they are explicitly defined.
 
-- `dimension`: String, required. The dimension to which the attribute
+- `dimension`: String, required if `row_security` is undefined. The dimension to which the attribute
   defined by `name` belongs.
+
+  - `row_security`: String, required if `dimension` and `name` are
+  undefined. Allows to include row security in the user defined aggregate.
 
 - `partition`: String, optional. Adds a partition to the aggregate, and
   determines whether it should be defined on the key column, name


### PR DESCRIPTION
- updated the UDA attribtes to include row_security property
- the rule is that either row_securty or dimension + name properties can be defined