### PR TITLE
[ATSCALE-45219] Document partition_rank and distribution_rank in aggregate attributes

### DIFF
--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -680,6 +680,18 @@ Supported properties:
   supports distribution keys, then the semantic engine uses the specified keys when
   creating the aggregate table.
 
+- `partition_rank`: Integer, optional. An integer between 1 and 128 that
+  controls the independent ordering priority of partition keys. Lower
+  values indicate higher priority. When multiple attributes define a
+  `partition`, the engine uses `partition_rank` to determine the order
+  in which partition keys are applied.
+
+- `distribution_rank`: Integer, optional. An integer between 1 and 128
+  that controls the independent ordering priority of distribution keys.
+  Lower values indicate higher priority. When multiple attributes define
+  a `distribution`, the engine uses `distribution_rank` to determine
+  the order in which distribution keys are applied.
+
 ## partitions
 
 - **Type:** array

--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -665,32 +665,58 @@ Supported properties:
 
   When the engine builds an instance of this aggregate, it creates
   a partition for each combination of values in the dimensional
-  attributes. The number of partitions depends on the
-  left-to-right order of the attributes, as well as the number of
-  values for each attribute.
+  attributes. By default, the order of partition keys follows the
+  left-to-right order of the attributes in the `attributes` array.
+  Use `partition_rank` to control partition key order independently
+  of the distribution key order.
 
-  Essentially, the partitioning key functions as a `GROUP BY`
-  column. Queries against the aggregate must use this dimensional
-  attribute in a `WHERE` clause. A good candidate for a
-  partitioning key is a set of dimensional attributes that
-  together have a few hundred to under 1000 value combinations.
+  Queries against the aggregate must use this dimensional attribute
+  in a `WHERE` clause. A good candidate for a partitioning key is a
+  set of dimensional attributes that together have a few hundred to
+  under 1000 value combinations.
 
 - `distribution`: String, optional. The distribution keys to use when
   creating the aggregate table. If your aggregate data warehouse
-  supports distribution keys, then the semantic engine uses the specified keys when
-  creating the aggregate table.
+  supports distribution keys, then the semantic engine uses the
+  specified keys when creating the aggregate table. By default, the
+  order of distribution keys follows the left-to-right order of the
+  attributes in the `attributes` array. Use `distribution_rank` to
+  control distribution key order independently of the partition key
+  order.
 
-- `partition_rank`: Integer, optional. An integer between 1 and 128 that
-  controls the independent ordering priority of partition keys. Lower
-  values indicate higher priority. When multiple attributes define a
-  `partition`, the engine uses `partition_rank` to determine the order
-  in which partition keys are applied.
+- `partition_rank`: Integer, optional. An integer between 1 and 128
+  that explicitly controls the order of partition keys, independently
+  of the distribution key order. Lower values indicate higher
+  priority. When set, `partition_rank` overrides the default
+  left-to-right attribute order for partitioning. Rank values must
+  be unique across all attributes that define a `partition` in the
+  same aggregate.
 
 - `distribution_rank`: Integer, optional. An integer between 1 and 128
-  that controls the independent ordering priority of distribution keys.
-  Lower values indicate higher priority. When multiple attributes define
-  a `distribution`, the engine uses `distribution_rank` to determine
-  the order in which distribution keys are applied.
+  that explicitly controls the order of distribution keys,
+  independently of the partition key order. Lower values indicate
+  higher priority. When set, `distribution_rank` overrides the
+  default left-to-right attribute order for distributions. Rank
+  values must be unique across all attributes that define a
+  `distribution` in the same aggregate.
+
+**Example** — partition order coarse-to-fine, distribution order high-cardinality-first:
+
+```yaml
+attributes:
+  - name: Year_Level
+    dimension: Gregorian_Calendar
+    partition: key
+    partition_rank: 1      # partition order: Year first
+    distribution: key
+    distribution_rank: 2   # distribution order: Year second
+  - name: Month_Level
+    dimension: Gregorian_Calendar
+    partition: key
+    partition_rank: 2      # partition order: Month second
+    distribution: key
+    distribution_rank: 1   # distribution order: Month first (higher cardinality)
+```
 
 ## partitions
 

--- a/sml-reference/model.md
+++ b/sml-reference/model.md
@@ -665,15 +665,16 @@ Supported properties:
 
   When the engine builds an instance of this aggregate, it creates
   a partition for each combination of values in the dimensional
-  attributes. By default, the order of partition keys follows the
-  left-to-right order of the attributes in the `attributes` array.
-  Use `partition_rank` to control partition key order independently
-  of the distribution key order.
+  attributes. Essentially, the partitioning key functions as a
+  `GROUP BY` column. Queries against the aggregate must use this
+  dimensional attribute in a `WHERE` clause. A good candidate for a
+  partitioning key is a set of dimensional attributes that together
+  have a few hundred to under 1000 value combinations.
 
-  Queries against the aggregate must use this dimensional attribute
-  in a `WHERE` clause. A good candidate for a partitioning key is a
-  set of dimensional attributes that together have a few hundred to
-  under 1000 value combinations.
+  By default, the order of partition keys follows the left-to-right
+  order of the attributes in the `attributes` array. Use
+  `partition_rank` to control partition key order independently of
+  the distribution key order.
 
 - `distribution`: String, optional. The distribution keys to use when
   creating the aggregate table. If your aggregate data warehouse
@@ -688,34 +689,35 @@ Supported properties:
   that explicitly controls the order of partition keys, independently
   of the distribution key order. Lower values indicate higher
   priority. When set, `partition_rank` overrides the default
-  left-to-right attribute order for partitioning. Rank values must
-  be unique across all attributes that define a `partition` in the
-  same aggregate.
+  left-to-right attribute order for partitioning. Rank values across
+  all attributes that define a `partition` in the same aggregate must
+  form a consecutive sequence starting from 1 (e.g. `1, 2, 3`).
 
 - `distribution_rank`: Integer, optional. An integer between 1 and 128
   that explicitly controls the order of distribution keys,
   independently of the partition key order. Lower values indicate
   higher priority. When set, `distribution_rank` overrides the
   default left-to-right attribute order for distributions. Rank
-  values must be unique across all attributes that define a
-  `distribution` in the same aggregate.
+  values across all attributes that define a `distribution` in the
+  same aggregate must form a consecutive sequence starting from 1
+  (e.g. `1, 2, 3`).
 
-**Example** — partition order coarse-to-fine, distribution order high-cardinality-first:
+**Example** — partition order and distribution order defined independently:
 
 ```yaml
 attributes:
-  - name: Year_Level
-    dimension: Gregorian_Calendar
+  - name: Year
+    dimension: Date Dimension
     partition: key
     partition_rank: 1      # partition order: Year first
     distribution: key
     distribution_rank: 2   # distribution order: Year second
-  - name: Month_Level
-    dimension: Gregorian_Calendar
+  - name: Month
+    dimension: Date Dimension
     partition: key
     partition_rank: 2      # partition order: Month second
     distribution: key
-    distribution_rank: 1   # distribution order: Month first (higher cardinality)
+    distribution_rank: 1   # distribution order: Month first
 ```
 
 ## partitions


### PR DESCRIPTION
## Summary

- Documents the `partition_rank` and `distribution_rank` integer properties (1–128) in the `attributes` section of the aggregate definition in `model.md`
- These properties were added to `SMLAggregatePartitionProperties` but were missing from the public SML reference docs

## Changes

- `sml-reference/model.md`: Added `partition_rank` and `distribution_rank` bullet points after the existing `partition` and `distribution` entries in the `### attributes` subsection

Jira: https://atscale.atlassian.net/browse/ATSCALE-45219