### PR TITLE
docs: add qds_materialization property to dataset spec

### DIFF
--- a/sml-reference/dataset.md
+++ b/sml-reference/dataset.md
@@ -453,9 +453,8 @@ use joins on dimensions that do not change often.
 - **Required:** N
 - **Added in:** v1.8
 
-Enables QDS (Query Data Store) materialization for the dataset. When set
-to `true`, the engine can materialize query results in the Query Data
-Store for improved query performance.
+Enables QDS (Query Dataset) materialization for the dataset. When set
+to `true`, the engine can materialize query results as an aggregate table for improved query performance.
 
 Only applicable to query datasets (those defined with `sql` rather than
 `table`).

--- a/sml-reference/dataset.md
+++ b/sml-reference/dataset.md
@@ -451,6 +451,7 @@ use joins on dimensions that do not change often.
 
 - **Type:** boolean
 - **Required:** N
+- **Added in:** v1.8
 
 Enables QDS (Query Data Store) materialization for the dataset. When set
 to `true`, the engine can materialize query results in the Query Data

--- a/sml-reference/dataset.md
+++ b/sml-reference/dataset.md
@@ -161,6 +161,7 @@ namespace Datasets{
       Array~Column~ columns
       Array~Dialect~ dialects
       Boolean immutable
+      Boolean qds_materialization
       Alternate alternate
       Incremental incremental
     }
@@ -445,3 +446,15 @@ seconds. Setting it to `'1w'` sets the grace period to one week.
 Determines whether the dataset changes often or not. The semantic engine
 uses this information when running incremental builds of aggregates that
 use joins on dimensions that do not change often.
+
+## qds_materialization
+
+- **Type:** boolean
+- **Required:** N
+
+Enables QDS (Query Data Store) materialization for the dataset. When set
+to `true`, the engine can materialize query results in the Query Data
+Store for improved query performance.
+
+Only applicable to query datasets (those defined with `sql` rather than
+`table`).


### PR DESCRIPTION
## Summary
- Add `qds_materialization` boolean property to the dataset documentation
- Add `qds_materialization` to the Entity Relationships class diagram
- Property is only applicable to query datasets (sql-based, not table-based)

## Test plan
- [ ] Review the new `qds_materialization` section in `sml-reference/dataset.md`
- [ ] Confirm accuracy with engineering team

**Do NOT merge until official AtScale release.**